### PR TITLE
remove '.env' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ coverage
 *DS_Store
 .classpath
 .project
-.env


### PR DESCRIPTION
during the lab several cf push commands were failing because
editing the .env file was not seen as a change, this is
because the .env file is tracked in .gitignore.

removing the file from .gitignore when pushing to bluemix, if
that is your only change, should now work.